### PR TITLE
Don't pass null to preg_replace()

### DIFF
--- a/classes/iterators/recursives/atoum/source.php
+++ b/classes/iterators/recursives/atoum/source.php
@@ -46,7 +46,7 @@ class source implements \outerIterator
     #[\ReturnTypeWillChange]
     public function key()
     {
-        return ($this->pharDirectory === null ? $this->innerIterator->key() : (preg_replace('#^(:[^:]+://)?' . preg_quote($this->sourceDirectory, '#') . '#', $this->pharDirectory, $this->innerIterator->current()) ?: null));
+        return ($this->pharDirectory === null ? $this->innerIterator->key() : (preg_replace('#^(:[^:]+://)?' . preg_quote($this->sourceDirectory, '#') . '#', $this->pharDirectory, $this->innerIterator->current() ?: '') ?: null));
     }
 
     #[\ReturnTypeWillChange]


### PR DESCRIPTION
Fix the error below but unfortunately the segfault is still there :(
```
# bin/atoum tests/units/classes/iterators/recursives/atoum/source.php
> atoum path: /code/atoum/bin/atoum
> atoum version: dev-master
> PHP path: /usr/local/bin/php
> PHP version:
=> PHP 8.1.0RC1 (cli) (built: Sep  2 2021 20:40:55) (NTS)
=> Copyright (c) The PHP Group
=> Zend Engine v4.1.0RC1, Copyright (c) Zend Technologies
> atoum\atoum\tests\units\iterators\recursives\atoum\source...
[SSSE________________________________________________________][4/4]
=> Test duration: 0.54 second.
=> Memory usage: 0.98 Mb.
> Total test duration: 0.54 second.
> Total test memory usage: 0.98 Mb.
> Running duration: 1.20 seconds.
Failure (1 test, 4/4 methods, 0 void method, 0 skipped method, 0 uncompleted method, 0 failure, 2 errors, 0 exception)!
> There are 2 errors:

=> atoum\atoum\tests\units\iterators\recursives\atoum\source::testKey():
==> Error E_DEPRECATED in /code/atoum/tests/units/classes/iterators/recursives/atoum/source.php on line 86, generated by file /code/atoum/classes/iterators/recursives/atoum/source.php on line 49:
preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated
==> Error E_DEPRECATED in /code/atoum/tests/units/classes/iterators/recursives/atoum/source.php on line 94, generated by file /code/atoum/classes/iterators/recursives/atoum/source.php on line 49:
preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated
```